### PR TITLE
Fixed Custom Options

### DIFF
--- a/source/funkin/states/OptionsState.hx
+++ b/source/funkin/states/OptionsState.hx
@@ -499,8 +499,14 @@ class OptionsState extends MusicBeatState
                         }
 
                         if (i >= 0)
-                            for (option in cast(cat.options, Array<Dynamic>))
-                                categories[i].options.push(option);
+                            if (categories[i].stateData != null)
+                            {
+                                categories[i].options = cat.options;
+                                categories[i].stateData = null;
+                            }
+                            else
+                                for (option in cast(cat.options, Array<Dynamic>))
+                                    categories[i].options.push(option);
                         else
                             categories.push(cast cat);
                     }


### PR DESCRIPTION
This PR contains a MAJOR fix and two minor fixes in terms of the Custom Options.
The MAJOR fix is that it fixes the crash with `options.json` because it doesn't actually use the right path, meaning the file is never loaded. So now, it actually loads the file.

The first minor fix that categories can be merged with the existing base game categories. So, if you name a category `"Gameplay"` in the JSON, the options from that category are merged into the existing Gameplay category. If you use Options in a category like `"Controls"` then the `stateData` will be removed in place of the `options` data.
The second minor fix is that you can use `stateData` in custom categories. Both states and substates already work out of the box. If your category is named after an existing one, then the category is overriden with your `stateData`. This is basically the first thing the options check for already, so it can override `options` based categories.